### PR TITLE
Fix manifest typo

### DIFF
--- a/walkthrough/webapp/Component.js
+++ b/walkthrough/webapp/Component.js
@@ -10,7 +10,7 @@ sap.ui.define(
     return UIComponent.extend("sap.ui.demo.walkthrough.Component", {
       metadata: {
         interfaces: ["sap.ui.core.IAsyncContentCreation"],
-        menifest: "json",
+        manifest: "json",
       },
       init: function () {
         // call the init function of the parent


### PR DESCRIPTION
## Summary
- fix incorrect `metadata` field name in Component.js

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fb370ac7c8322865787acba6554ab