### PR TITLE
Fix unitTests module path

### DIFF
--- a/walkthrough/webapp/test/unit/unitTests.qunit.js
+++ b/walkthrough/webapp/test/unit/unitTests.qunit.js
@@ -6,7 +6,7 @@ sap.ui.getCore().attachInit(function () {
   "use strict";
 
   sap.ui.require(
-    ["sap/ui/demo/walkthrough/test/unit/model/formatter"],
+    ["sap/ui/demo/walkthrough/test/unit/formatter"],
     function () {
       QUnit.start();
     }


### PR DESCRIPTION
## Summary
- correct the path to `formatter` in unitTests config

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fb445dc648322bbebea758d62beae