### PR TITLE
Add dialog close test step

### DIFF
--- a/walkthrough/webapp/test/integration/NavigationJourney.js
+++ b/walkthrough/webapp/test/integration/NavigationJourney.js
@@ -28,6 +28,12 @@ sap.ui.define(
       // Assertions
       Then.onTheAppPage.iShouldSeeTheHelloDialog();
 
+      //Actions
+      When.onTheAppPage.iPressTheOkButtonOnTheDialog();
+
+      // Assertions
+      Then.onTheAppPage.iShouldNotSeeAnyDialog();
+
       // Cleanup
       Then.iTeardownMyApp();
     });

--- a/walkthrough/webapp/test/integration/pages/App.js
+++ b/walkthrough/webapp/test/integration/pages/App.js
@@ -17,6 +17,16 @@ sap.ui.define(
                 "Did not find the 'Say Hello With Dialog' button on the HelloPanel view",
             });
           },
+          iPressTheOkButtonOnTheDialog: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              properties: {
+                text: "Ok",
+              },
+              actions: new Press(),
+              errorMessage: "Did not find the 'Ok' button on the dialog",
+            });
+          },
         },
 
         assertions: {
@@ -28,6 +38,20 @@ sap.ui.define(
                 Opa5.assert.ok(true, "The dialog is open");
               },
               errorMessage: "Did not find the dialog control",
+            });
+          },
+          iShouldNotSeeAnyDialog: function () {
+            return this.waitFor({
+              controlType: "sap.m.Dialog",
+              visible: true,
+              searchOpenDialogs: true,
+              check: function (aDialogs) {
+                return aDialogs.length === 0;
+              },
+              success: function () {
+                Opa5.assert.ok(true, "The dialog is closed");
+              },
+              errorMessage: "The dialog is still open",
             });
           },
         },


### PR DESCRIPTION
## Summary
- update test page object for closing dialog
- verify no dialog remains open
- enhance integration test to close dialog

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fb44e30648322997f5d942ab60774